### PR TITLE
feat: Add port configuration for server status checks

### DIFF
--- a/.upptimerc.yml
+++ b/.upptimerc.yml
@@ -5,9 +5,11 @@ sites:
   - name: Server Status V4
     check: "tcp-ping"
     url: $SERVER_IP_V4
+    port: $SERVER_PORT
   - name: Server Status V6
     check: "tcp-ping"
     url: $SERVER_IP_V6
+    port: $SERVER_PORT
 
 assignees:
   - hra42


### PR DESCRIPTION
Add SERVER_PORT environment variable to both V4 and V6 server
status checks. This change allows for more flexible configuration
and ensures that the correct port is used when checking server
status, improving the accuracy of the monitoring system.